### PR TITLE
[iOS8] init is not called during initWithFrame

### DIFF
--- a/GCBActionSheet.m
+++ b/GCBActionSheet.m
@@ -33,13 +33,25 @@
 
 - (id)init {
 	if ((self = [super init])) {
-		_buttonHandlers = [[NSMutableArray alloc] init];
+		[self commonInit];
 	}
 	return self;
 }
 
 - (id)initWithTitle:(NSString *)title delegate:(id<UIActionSheetDelegate>)delegate {
-	return [self initWithTitle:title delegate:delegate cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil];
+	if ((self = [super initWithTitle:title
+	                        delegate:delegate
+	               cancelButtonTitle:nil
+	          destructiveButtonTitle:nil
+	               otherButtonTitles:nil])) {
+		[self commonInit];
+	}
+	return self;
+}
+
+- (void)commonInit
+{
+	_buttonHandlers = [[NSMutableArray alloc] init];
 }
 
 #if !__has_feature(objc_arc)


### PR DESCRIPTION
This issue causes a crash under iOS 8.

init is no longer called in UIActionSheet's initWithTitle, so
_buttonHandlers was never initialized under iOS 8. Extract common
inititalization functions into - (void)commonInit to be called by init
and initWithTitle.
